### PR TITLE
return an instance of `Response` object

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,19 @@ The `track` method returns a Promise that can be `await`ed using the async/await
 
 ```javascript
 const response = await Hellotext.track("page.viewed");
-// {status: "received", success: true}
+```
+
+The return of the `Hellotext.track` method is an instance of a `Response` object that ships with the package. You can check the status of the response via methods, like
+
+```javascript
+if(response.failed) {
+  console.log("failed because", response.data)
+}
+
+if(response.succeeded) {
+  console.log("success")
+  console.log(response.data) // { status: "received" }
+}
 ```
 
 The parameters passed to the action must be a valid set of parameters as described in
@@ -66,6 +78,13 @@ Failing to provide valid set of parameters will result in an error object being 
 
 ```javascript
 const response = await Hellotext.track("app.installed", { app_attributes: { name: "My App" }})
+
+console.log(response.data)
+```
+
+yields
+
+```javascript
 {
   errors: [
     {

--- a/__tests__/hellotext_test.js
+++ b/__tests__/hellotext_test.js
@@ -46,7 +46,7 @@ describe("when the class is initialized successfully", () => {
 
         const response = await Hellotext.track("page.viewed")
 
-        expect(response.success).toEqual(true)
+        expect(response.succeeded).toEqual(true)
       });
 
       it("success attribute is false when response from the server is rejected", async () => {
@@ -57,7 +57,7 @@ describe("when the class is initialized successfully", () => {
 
         const response = await Hellotext.track("page.viewed")
 
-        expect(response.success).toEqual(false)
+        expect(response.failed).toEqual(true)
       });
     });
   });

--- a/lib/hellotext.js
+++ b/lib/hellotext.js
@@ -1,5 +1,6 @@
 import Event from "./event"
 import EventEmitter from "./eventEmitter"
+import Response from "./response";
 
 import { NotInitializedError } from './errors/notInitializedError'
 import { InvalidEvent } from "./errors/invalidEvent"
@@ -54,10 +55,7 @@ class Hellotext {
       }),
     })
 
-    const body = await response.json()
-    body.success = response.status === 200
-
-    return body
+    return new Response(response.status === 200, await response.json)
   }
 
   /**

--- a/lib/response.js
+++ b/lib/response.js
@@ -1,0 +1,21 @@
+export default class Response {
+  #success
+  #response
+
+  constructor(success, response) {
+    this.#success = success
+    this.#response = response
+  }
+
+  data() {
+    return this.#response
+  }
+
+  get failed() {
+    return this.#success === false
+  }
+
+  get succeeded() {
+    return this.#success === true
+  }
+}


### PR DESCRIPTION
When tracking using `Hellotext.track`, return an instance of `Response` object that provides accessor methods to determine the state of the Response. 

You can check the status of the response via `Response#failed` and `Response#succeeded` getter methods. Additionally, the response's data can simply be accessed via `Response#data` 