### PR TITLE
Secure checkout credentials in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,9 @@ jobs:
         node: ["20", "22"]
     name: Node ${{ matrix.node }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node }}


### PR DESCRIPTION
## Summary

- Bump `actions/checkout` from v6 to v7.
- Disable persisted Git credentials for the CI checkout step.

## Why

This prevents later workflow steps or third-party actions from reading the default `GITHUB_TOKEN` from the repository's local Git configuration.